### PR TITLE
Fix use of open for GitHub URI

### DIFF
--- a/lib/jekyll_github_sample/code_tag.rb
+++ b/lib/jekyll_github_sample/code_tag.rb
@@ -16,7 +16,7 @@ module JekyllGithubSample
 
     def render(context)
       all_lines = cache.fetch(@github_file.raw_uri) do
-        open(@github_file.raw_uri).readlines
+        URI.open(@github_file.raw_uri).readlines
       end
       if @line_start.respond_to?(:match) and tag_match = @line_start.match(/^tag:(.*)/)
         lines     = extract_tagged_lines(all_lines, tag_match[1])


### PR DESCRIPTION
The original code used 'open' which was apparently calling Kernel#open
versus URI#open which I assume the author originally expected to use
since open-uri was being required at the top of the file. This fix
forces the use of the open method in the URI library.

This PR is intended to address issue #19.
